### PR TITLE
Fixed enum bitpacking in basic_function.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,8 +4,9 @@ BUILD_FOLDER = build/basic
 
 SOURCE_FOLDERS += ./arch/osx ./src
 
-CC = gcc-10
-CFLAGS = -g -Wall -Werror -std=c99 -lreadline -lm -DARCH_OSX=1 -DARCH_XMEGA=2 -DARCH=1
+CC = gcc
+CFLAGS = -g -Wall -Werror -std=c99 -DARCH_OSX=1 -DARCH_XMEGA=2 -DARCH=1
+LDFLAGS = -lreadline -lm
 
 VPATH = $(SOURCE_FOLDERS)
 

--- a/src/parser.c
+++ b/src/parser.c
@@ -831,7 +831,7 @@ string_term(void)
         size_t vector[5];
         get_vector(vector,5);
         string = C_STRDUP(variable_array_get_string(var_name, vector));
-        if (string == NULL) string = &_dummy;
+        if (string == NULL) string = (char*)&_dummy;
 
         expect(T_RIGHT_BANANA);
       }
@@ -908,7 +908,7 @@ do_print(basic_type* rv)
         expression(&expr);
         expression_print(&expr);
         if (expr.type == expression_type_string){
-            if (expr.value.string != &_dummy)
+            if (expr.value.string != (char*)&_dummy)
                 free(expr.value.string);
         }
       }
@@ -2066,10 +2066,8 @@ int do_sleep(basic_type* delay, basic_type* rv)
   nanosleep(&ts, NULL);
 
 #endif
-  struct timespec ts;
-  ts.tv_sec = milliseconds / 1000;
-  ts.tv_nsec = (milliseconds % 1000) * 1000000;
-  nanosleep(&ts, NULL);
+#else
+  Sleep(milliseconds);
 #endif
 
   rv->kind = kind_numeric;

--- a/src/parser.c
+++ b/src/parser.c
@@ -134,8 +134,8 @@ typedef union
 
 typedef struct {
   token token;
-  basic_function_type type : 3;
-  size_t nr_arguments : 3;
+  basic_function_type type : 4;
+  size_t nr_arguments : 4;
   kind kind_1 : 1;
   kind kind_2 : 1;
   kind kind_3 : 1;

--- a/src/tokenizer.c
+++ b/src/tokenizer.c
@@ -244,7 +244,7 @@ char *tokenizer_get_string(void)
 
 void tokenizer_get_variable_name(char *name)
 {
-  strncpy(name, tokenizer_actual_variable, sizeof(tokenizer_actual_variable));
+  strncpy(name, &tokenizer_actual_variable[0], sizeof(tokenizer_actual_variable));
 }
 
   void


### PR DESCRIPTION
GCC uses unsigned for enum, unless the enum includes explicit negative assignments. MSVC appears to default to signed. Bitpacking here creates errors if the enum is signed because the maximum value for 3 bits is 3, not 7.

The easy solution is to add an extra bit for signed/unsigned.

I wonder also if bitpacking is necessary?